### PR TITLE
Add missed import to Base resource

### DIFF
--- a/src/Resource/Base.php
+++ b/src/Resource/Base.php
@@ -11,6 +11,7 @@ use SMSGlobal\Exceptions\AuthenticationException;
 use SMSGlobal\Exceptions\CredentialsException;
 use SMSGlobal\Exceptions\InvalidPayloadException;
 use SMSGlobal\Exceptions\InvalidResponseException;
+use SMSGlobal\Exceptions\PaymentRequiredException;
 use SMSGlobal\Exceptions\ResourceNotFoundException;
 
 /**


### PR DESCRIPTION
Tests run locally:
```console
$ ./vendor/bin/phpunit tests
PHPUnit 8.5.15 by Sebastian Bergmann and contributors.

.......................................                           39 / 39 (100%)

Time: 444 ms, Memory: 8.00 MB

OK (39 tests, 48 assertions)
```

Closes #7 