### PR TITLE
Remove json_encode from Sms::sendToMultiple

### DIFF
--- a/src/Resource/Sms.php
+++ b/src/Resource/Sms.php
@@ -58,7 +58,7 @@ class Sms extends Base
         $origin = !empty($from) ? $from : '';
 
         return $this->rawPayload([
-            "destinations" => json_encode($to),
+            "destinations" => $to,
             "message" => $text,
             "origin" => $origin
         ]);


### PR DESCRIPTION
Tests on local machine:
```console
$ ./vendor/bin/phpunit tests
PHPUnit 8.5.15 by Sebastian Bergmann and contributors.

.......................................                           39 / 39 (100%)

Time: 410 ms, Memory: 8.00 MB

OK (39 tests, 48 assertions)
```

Closes #8 